### PR TITLE
feat: enhance PageHeader component with topicHome prop

### DIFF
--- a/src/app/frontend/junior/html&css/html-css.tsx
+++ b/src/app/frontend/junior/html&css/html-css.tsx
@@ -15,6 +15,7 @@ export default function HTMLCSSComponent() {
       <PageHeader
         description='Semantic HTML, accessibility basics, Flexbox, Grid, responsive design'
         title='HTML & CSS Notes'
+        topicHome='/frontend/junior'
       />
 
       {/* Spacer to account for fixed header */}

--- a/src/components/page-header/page-header.tsx
+++ b/src/components/page-header/page-header.tsx
@@ -1,12 +1,17 @@
-import { House } from 'lucide-react';
+import { BookOpenCheck, House } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
 interface PageHeaderProps {
   title: string;
   description: string;
+  topicHome?: string;
 }
 
-export const PageHeader = ({ title, description }: PageHeaderProps) => {
+export const PageHeader = ({
+  description,
+  title,
+  topicHome,
+}: PageHeaderProps) => {
   const router = useRouter();
 
   return (
@@ -19,14 +24,26 @@ export const PageHeader = ({ title, description }: PageHeaderProps) => {
             </h1>
             <p className='text-gray-50'>{description}</p>
           </div>
-          <button
-            aria-label='Go to home page'
-            className='text-white transition-colors hover:text-yellow-500'
-            onClick={() => router.push('/')}
-            type='button'
-          >
-            <House size={24} />
-          </button>
+          <div className='flex items-center gap-4'>
+            {topicHome && (
+              <button
+                aria-label='Go to topic home'
+                className='text-white transition-colors hover:text-yellow-500'
+                onClick={() => router.push(topicHome)}
+                type='button'
+              >
+                <BookOpenCheck size={24} />
+              </button>
+            )}
+            <button
+              aria-label='Go to home page'
+              className='text-white transition-colors hover:text-yellow-500'
+              onClick={() => router.push('/')}
+              type='button'
+            >
+              <House size={24} />
+            </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Added a new optional prop `topicHome` to the PageHeader component for improved navigation.
- Updated HTMLCSSComponent to utilize the new `topicHome` prop, linking to the junior frontend section.
- Introduced a new button in the PageHeader for navigating to the specified topic home.