### PR TITLE
Add blurred background and TOC navigation

### DIFF
--- a/src/app/frontend/junior/html&css/html-css.tsx
+++ b/src/app/frontend/junior/html&css/html-css.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PageHeader } from '@/components';
+import { PageHeader, TableOfContents } from '@/components';
 import {
   CssFlexbox,
   CssFunctionsAndModernFeatures,
@@ -20,6 +20,8 @@ export default function HTMLCSSComponent() {
 
       {/* Spacer to account for fixed header */}
       <div className='h-[140px]' />
+
+      <TableOfContents />
 
       <div className='mx-auto max-w-4xl px-6 py-8'>
         <div className='prose prose-invert prose-zinc max-w-none'>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,12 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background: radial-gradient(circle at 20% 20%, #1e3a8a, transparent 70%);
+  filter: blur(80px);
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,4 +2,5 @@ export * from './code-block';
 export * from './notes-area';
 export * from './page-header';
 export * from './section-card';
+export * from './table-of-contents';
 export * from './typography';

--- a/src/components/section-card/section-card.tsx
+++ b/src/components/section-card/section-card.tsx
@@ -1,11 +1,14 @@
+import { slugify } from '@/helpers/slugify';
+
 interface SectionCardProps {
   title: string;
   children: React.ReactNode;
 }
 
 export const SectionCard = ({ title, children }: SectionCardProps) => {
+  const id = slugify(title);
   return (
-    <section className='mb-12 border border-zinc-800 bg-zinc-900 p-6'>
+    <section className='mb-12 border border-zinc-800 bg-zinc-900 p-6' id={id}>
       <h2 className='mb-4 border-zinc-700 border-b pb-2 font-bold text-2xl text-white'>
         {title}
       </h2>

--- a/src/components/table-of-contents/index.ts
+++ b/src/components/table-of-contents/index.ts
@@ -1,0 +1,1 @@
+export { TableOfContents } from './table-of-contents';

--- a/src/components/table-of-contents/table-of-contents.tsx
+++ b/src/components/table-of-contents/table-of-contents.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Pin } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+interface TocItem {
+  id: string;
+  text: string;
+  level: number;
+}
+
+export const TableOfContents = () => {
+  const [items, setItems] = useState<TocItem[]>([]);
+  const [open, setOpen] = useState(false);
+  const [pinned, setPinned] = useState(false);
+  const [touchStart, setTouchStart] = useState<number | null>(null);
+
+  useEffect(() => {
+    const headings = Array.from(
+      document.querySelectorAll<HTMLElement>('h2[id], h3[id]')
+    );
+    const mapped = headings.map((el) => ({
+      id: el.id,
+      text: el.textContent || '',
+      level: el.tagName === 'H2' ? 2 : 3,
+    }));
+    setItems(mapped);
+  }, []);
+
+  useEffect(() => {
+    const handleTouchStart = (e: TouchEvent) => {
+      if (window.innerWidth < 768) {
+        setTouchStart(e.touches[0].clientX);
+      }
+    };
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (window.innerWidth < 768 && touchStart !== null) {
+        const diff = e.changedTouches[0].clientX - touchStart;
+        if (touchStart < 30 && diff > 40) {
+          setOpen(true);
+        }
+      }
+      setTouchStart(null);
+    };
+    window.addEventListener('touchstart', handleTouchStart);
+    window.addEventListener('touchend', handleTouchEnd);
+    return () => {
+      window.removeEventListener('touchstart', handleTouchStart);
+      window.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [touchStart]);
+
+  const handleMouseLeave = () => {
+    if (!pinned) {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <nav className='fixed top-20 left-0 z-40'>
+      <button
+        className='group'
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={handleMouseLeave}
+        type='button'
+      >
+        <motion.div
+          animate={{ x: open ? 0 : '-100%' }}
+          className='relative max-h-[80vh] w-56 overflow-y-auto bg-zinc-900/90 p-4 pr-6 text-sm text-white backdrop-blur-lg'
+        >
+          <ul className='space-y-2'>
+            {items.map((item) => (
+              <li className={item.level === 3 ? 'ml-4' : ''} key={item.id}>
+                <a
+                  className='hover:text-yellow-500'
+                  href={`#${item.id}`}
+                  onClick={() => setOpen(false)}
+                >
+                  {item.text}
+                </a>
+              </li>
+            ))}
+          </ul>
+          <button
+            className='-right-6 absolute top-2 hidden md:block'
+            onClick={() => setPinned(!pinned)}
+            type='button'
+          >
+            <Pin className={pinned ? 'fill-white' : ''} size={20} />
+          </button>
+        </motion.div>
+      </button>
+    </nav>
+  );
+};

--- a/src/components/typography/header.tsx
+++ b/src/components/typography/header.tsx
@@ -1,12 +1,18 @@
+import { slugify } from '@/helpers/slugify';
+
 interface HeaderProps {
   children: React.ReactNode;
   className?: string;
+  id?: string;
 }
 
-export const Header = ({ children, className = '' }: HeaderProps) => {
+export const Header = ({ children, className = '', id }: HeaderProps) => {
+  const text = typeof children === 'string' ? children : '';
+  const headerId = id || slugify(text);
   return (
     <h3
       className={`mb-3 font-bold text-xl underline decoration-2 underline-offset-4 ${className}`}
+      id={headerId}
     >
       {children}
     </h3>

--- a/src/helpers/slugify.ts
+++ b/src/helpers/slugify.ts
@@ -1,0 +1,6 @@
+export const slugify = (text: string): string =>
+  text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');


### PR DESCRIPTION
## Summary
- generate IDs for SectionCard and Header for anchors
- implement new TableOfContents component with hover and swipe behaviour
- expose the TOC from component index and use in HTML & CSS page
- add radial blur background styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d6f3fd7508328960a689ac977c854