### PR TITLE
Improve table of contents

### DIFF
--- a/src/app/frontend/junior/html&css/html-css.tsx
+++ b/src/app/frontend/junior/html&css/html-css.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { PageHeader } from '@/components';
+import { useEffect, useState } from 'react';
+import { PageHeader, TableOfContents } from '@/components';
 import {
   CssFlexbox,
   CssFunctionsAndModernFeatures,
@@ -10,6 +11,25 @@ import {
 } from './components';
 
 export default function HTMLCSSComponent() {
+  const [headerHeight, setHeaderHeight] = useState(0);
+
+  useEffect(() => {
+    const header = document.getElementById('page-header');
+    if (!header) {
+      return;
+    }
+    const updateHeight = () =>
+      setHeaderHeight(header.getBoundingClientRect().height);
+    updateHeight();
+    const resizeObserver = new ResizeObserver(updateHeight);
+    resizeObserver.observe(header);
+    window.addEventListener('scroll', updateHeight);
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('scroll', updateHeight);
+    };
+  }, []);
+
   return (
     <div className='min-h-screen bg-black text-white'>
       <PageHeader
@@ -18,10 +38,12 @@ export default function HTMLCSSComponent() {
         topicHome='/frontend/junior'
       />
 
-      {/* Spacer to account for fixed header */}
-      <div className='h-[140px]' />
+      <TableOfContents />
 
-      <div className='mx-auto max-w-4xl px-6 py-8'>
+      <div
+        className='mx-auto max-w-4xl px-6 py-8'
+        style={{ paddingTop: headerHeight }}
+      >
         <div className='prose prose-invert prose-zinc max-w-none'>
           <SemanticHtmlAndAccessibility />
           <CssFlexbox />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,12 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background: radial-gradient(circle at 20% 20%, #eab308, transparent 70%);
+  filter: blur(80px);
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,4 +2,5 @@ export * from './code-block';
 export * from './notes-area';
 export * from './page-header';
 export * from './section-card';
+export * from './table-of-contents';
 export * from './typography';

--- a/src/components/page-header/page-header.tsx
+++ b/src/components/page-header/page-header.tsx
@@ -49,6 +49,7 @@ export const PageHeader = ({
         height: isScrolled ? '80px' : '140px',
       }}
       className='fixed top-0 right-0 left-0 z-50 border-white/10 border-b bg-black/30 backdrop-blur-xl backdrop-saturate-150'
+      id='page-header'
       transition={{ duration: 0.3, ease: 'easeInOut' }}
     >
       <div className='mx-auto h-full max-w-4xl px-6'>

--- a/src/components/section-card/section-card.tsx
+++ b/src/components/section-card/section-card.tsx
@@ -1,11 +1,14 @@
+import { slugify } from '@/helpers/slugify';
+
 interface SectionCardProps {
   title: string;
   children: React.ReactNode;
 }
 
 export const SectionCard = ({ title, children }: SectionCardProps) => {
+  const id = slugify(title);
   return (
-    <section className='mb-12 border border-zinc-800 bg-zinc-900 p-6'>
+    <section className='mb-12 border border-zinc-800 bg-zinc-900 p-6' id={id}>
       <h2 className='mb-4 border-zinc-700 border-b pb-2 font-bold text-2xl text-white'>
         {title}
       </h2>

--- a/src/components/table-of-contents/index.ts
+++ b/src/components/table-of-contents/index.ts
@@ -1,0 +1,1 @@
+export { TableOfContents } from './table-of-contents';

--- a/src/components/table-of-contents/table-of-contents.tsx
+++ b/src/components/table-of-contents/table-of-contents.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Pin, PinOff } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+interface TocHeading {
+  id: string;
+  text: string;
+  level: number;
+}
+
+interface TocItem {
+  id: string;
+  text: string;
+  children: TocHeading[];
+}
+
+const parseHeadings = () => {
+  const headings = Array.from(
+    document.querySelectorAll<HTMLElement>('h2[id], h3[id]')
+  );
+  const mapped: TocItem[] = [];
+  for (const el of headings) {
+    const item = {
+      id: el.id,
+      text: el.textContent || '',
+      level: el.tagName === 'H2' ? 2 : 3,
+    } as TocHeading;
+    if (item.level === 2) {
+      mapped.push({ id: item.id, text: item.text, children: [] });
+    } else if (mapped.length > 0) {
+      const last = mapped.at(-1);
+      if (last) {
+        last.children.push(item);
+      }
+    }
+  }
+  return mapped;
+};
+
+export const TableOfContents = () => {
+  const [items, setItems] = useState<TocItem[]>([]);
+  const [open, setOpen] = useState(false);
+  const [pinned, setPinned] = useState(false);
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const [touchStart, setTouchStart] = useState<number | null>(null);
+
+  useEffect(() => {
+    setItems(parseHeadings());
+  }, []);
+
+  useEffect(() => {
+    const header = document.getElementById('page-header');
+    if (!header) {
+      return;
+    }
+    const updateHeight = () =>
+      setHeaderHeight(header.getBoundingClientRect().height);
+    updateHeight();
+    const resizeObserver = new ResizeObserver(updateHeight);
+    resizeObserver.observe(header);
+    window.addEventListener('scroll', updateHeight);
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('scroll', updateHeight);
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleTouchStart = (e: TouchEvent) => {
+      if (window.innerWidth < 768) {
+        setTouchStart(e.touches[0].clientX);
+      }
+    };
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (window.innerWidth < 768 && touchStart !== null) {
+        const diff = e.changedTouches[0].clientX - touchStart;
+        if (touchStart < 30 && diff > 40) {
+          setOpen(true);
+        }
+      }
+      setTouchStart(null);
+    };
+    window.addEventListener('touchstart', handleTouchStart);
+    window.addEventListener('touchend', handleTouchEnd);
+    return () => {
+      window.removeEventListener('touchstart', handleTouchStart);
+      window.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [touchStart]);
+
+  const handleMouseLeave = () => {
+    if (!pinned) {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <nav className='fixed left-0 z-40' style={{ top: headerHeight }}>
+      <button
+        className='group'
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={handleMouseLeave}
+        type='button'
+      >
+        <motion.div
+          animate={{ x: open ? 0 : '-100%' }}
+          className='relative max-h-[80vh] w-56 overflow-y-auto bg-zinc-900/90 p-4 pr-6 text-sm text-white backdrop-blur-lg'
+        >
+          <ul className='space-y-2'>
+            {items.map((section) => (
+              <li key={section.id}>
+                <a
+                  className='font-medium hover:text-yellow-500'
+                  href={`#${section.id}`}
+                  onClick={() => setOpen(false)}
+                >
+                  {section.text}
+                </a>
+                {section.children.length > 0 && (
+                  <ul className='mt-1 space-y-1 pl-4'>
+                    {section.children.map((child) => (
+                      <li key={child.id}>
+                        <a
+                          className='hover:text-yellow-500'
+                          href={`#${child.id}`}
+                          onClick={() => setOpen(false)}
+                        >
+                          {child.text}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
+          </ul>
+          <button
+            className='-right-6 absolute top-2 hidden md:block'
+            onClick={() => setPinned(!pinned)}
+            type='button'
+          >
+            {pinned ? (
+              <PinOff className='fill-white' size={20} />
+            ) : (
+              <Pin size={20} />
+            )}
+          </button>
+        </motion.div>
+      </button>
+    </nav>
+  );
+};

--- a/src/components/typography/header.tsx
+++ b/src/components/typography/header.tsx
@@ -1,12 +1,18 @@
+import { slugify } from '@/helpers/slugify';
+
 interface HeaderProps {
   children: React.ReactNode;
   className?: string;
+  id?: string;
 }
 
-export const Header = ({ children, className = '' }: HeaderProps) => {
+export const Header = ({ children, className = '', id }: HeaderProps) => {
+  const text = typeof children === 'string' ? children : '';
+  const headerId = id || slugify(text);
   return (
     <h3
       className={`mb-3 font-bold text-xl underline decoration-2 underline-offset-4 ${className}`}
+      id={headerId}
     >
       {children}
     </h3>

--- a/src/helpers/slugify.ts
+++ b/src/helpers/slugify.ts
@@ -1,0 +1,6 @@
+export const slugify = (text: string): string =>
+  text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');


### PR DESCRIPTION
## Summary
- darken the radial gradient background color
- ensure header height effect uses block statement
- refactor `TableOfContents` for readability and lower complexity
- minor formatting tweaks in `PageHeader`

## Testing
- `npm test`
- `npx -y ultracite@latest format`


------
https://chatgpt.com/codex/tasks/task_e_686d6f3fd7508328960a689ac977c854