### PR TITLE
Add JavaScript fundamentals section

### DIFF
--- a/src/app/frontend/junior/frontend-junior.tsx
+++ b/src/app/frontend/junior/frontend-junior.tsx
@@ -17,10 +17,10 @@ const sections: Section[] = [
     inProgress: false,
   },
   {
-    href: '#',
+    href: '/frontend/junior/javascript-fundamentals',
     title: 'JavaScript Fundamentals',
     description: 'ES6+ syntax, scope, closures, async patterns, DOM APIs',
-    inProgress: true,
+    inProgress: false,
   },
   {
     href: '#',

--- a/src/app/frontend/junior/javascript-fundamentals/components/arrays-and-objects.tsx
+++ b/src/app/frontend/junior/javascript-fundamentals/components/arrays-and-objects.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import dedent from 'dedent';
+import { CodeBlock, CodeSpan, Header, SectionCard, Subheader, Text } from '@/components';
+
+export function ArraysAndObjects() {
+  return (
+    <SectionCard title='Arrays & Objects'>
+      <div className='space-y-6'>
+        <div>
+          <Header>Working with Arrays</Header>
+          <Text>
+            Arrays hold ordered lists of values. Useful helpers include <CodeSpan>map</CodeSpan>, <CodeSpan>filter</CodeSpan> and <CodeSpan>find</CodeSpan>.
+          </Text>
+        </div>
+
+        {(() => {
+          const arrayCode = dedent`const numbers = [1, 2, 3];
+const doubled = numbers.map(n => n * 2); // [2, 4, 6]`;
+          return (
+            <CodeBlock
+              code={arrayCode}
+              comment='Array example'
+              language='javascript'
+              showLineNumbers={true}
+            />
+          );
+        })()}
+
+        <div>
+          <Subheader>Objects</Subheader>
+          <Text>
+            Objects store key–value pairs. Use dot or bracket notation to access properties.
+          </Text>
+        </div>
+
+        {(() => {
+          const objCode = dedent`const user = { id: 1, name: 'Sam' };
+console.log(user.name); // Sam`;
+          return (
+            <CodeBlock
+              code={objCode}
+              comment='Object example'
+              language='javascript'
+              showLineNumbers={true}
+            />
+          );
+        })()}
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/app/frontend/junior/javascript-fundamentals/components/async-javascript.tsx
+++ b/src/app/frontend/junior/javascript-fundamentals/components/async-javascript.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import dedent from 'dedent';
+import { Callout, CodeBlock, CodeSpan, Header, SectionCard, Subheader, Text } from '@/components';
+
+export function AsyncJavaScript() {
+  return (
+    <SectionCard title='Async JavaScript'>
+      <div className='space-y-6'>
+        <div>
+          <Header>Promises & Async/Await</Header>
+          <Text>
+            Promises represent work that finishes in the future. <CodeSpan>async</CodeSpan>/<CodeSpan>await</CodeSpan> lets you write promise code that looks synchronous.
+          </Text>
+        </div>
+
+        {(() => {
+          const code = dedent`async function getUser() {
+  const res = await fetch('/api/user');
+  return res.json();
+}
+
+getUser().then(user => console.log(user));`;
+          return (
+            <CodeBlock
+              code={code}
+              comment='Fetching data'
+              language='javascript'
+              showLineNumbers={true}
+            />
+          );
+        })()}
+
+        <Callout>
+          <strong>Senior note:</strong> Unhandled promise rejections can crash Node.js processes in strict mode. Always add error handling.
+        </Callout>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/app/frontend/junior/javascript-fundamentals/components/dom-manipulation.tsx
+++ b/src/app/frontend/junior/javascript-fundamentals/components/dom-manipulation.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import dedent from 'dedent';
+import { Callout, CodeBlock, CodeSpan, Header, SectionCard, Subheader, Text } from '@/components';
+
+export function DomManipulation() {
+  return (
+    <SectionCard title='DOM Manipulation'>
+      <div className='space-y-6'>
+        <div>
+          <Header>Selecting Elements</Header>
+          <Text>
+            Use <CodeSpan>document.querySelector</CodeSpan> to grab the first element that matches a CSS selector.
+          </Text>
+        </div>
+
+        {(() => {
+          const code = dedent`const button = document.querySelector('button');
+button.addEventListener('click', () => {
+  alert('Clicked!');
+});`;
+          return (
+            <CodeBlock
+              code={code}
+              comment='Basic event listener'
+              language='javascript'
+              showLineNumbers={true}
+            />
+          );
+        })()}
+
+        <Callout>
+          Changing the DOM too often can slow things down. Batch updates when possible.
+        </Callout>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/app/frontend/junior/javascript-fundamentals/components/functions-and-scope.tsx
+++ b/src/app/frontend/junior/javascript-fundamentals/components/functions-and-scope.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import dedent from 'dedent';
+import { Callout, CodeBlock, CodeSpan, Header, SectionCard, Subheader, Text } from '@/components';
+
+export function FunctionsAndScope() {
+  return (
+    <SectionCard title='Functions & Scope'>
+      <div className='space-y-6'>
+        <div>
+          <Header>Function Basics</Header>
+          <Text>
+            Functions let you reuse logic. They can be declared or stored in variables.
+          </Text>
+        </div>
+
+        {(() => {
+          const code = dedent`function greet(name) {
+  return 'Hi ' + name;
+}
+
+const greetArrow = (name) => 'Hi ' + name;`;
+          return (
+            <CodeBlock
+              code={code}
+              comment='Two ways to declare'
+              language='javascript'
+              showLineNumbers={true}
+            />
+          );
+        })()}
+
+        <div>
+          <Subheader>Scope & Closures</Subheader>
+          <Text>
+            Variables are visible only inside the block they are defined in. Functions keep access to the variables from where they were created.
+          </Text>
+        </div>
+
+        {(() => {
+          const closureCode = dedent`function makeCounter() {
+  let count = 0;
+  return () => ++count;
+}
+
+const counter = makeCounter();
+counter(); // 1
+counter(); // 2`;
+          return (
+            <CodeBlock
+              code={closureCode}
+              comment='Simple closure'
+              language='javascript'
+              showLineNumbers={true}
+            />
+          );
+        })()}
+
+        <Callout>
+          <strong>Senior note:</strong> Closures are the basis for many patterns like currying and modules.
+        </Callout>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/app/frontend/junior/javascript-fundamentals/components/index.ts
+++ b/src/app/frontend/junior/javascript-fundamentals/components/index.ts
@@ -1,0 +1,6 @@
+export * from './js-basics';
+export * from './variables-and-data-types';
+export * from './functions-and-scope';
+export * from './arrays-and-objects';
+export * from './dom-manipulation';
+export * from './async-javascript';

--- a/src/app/frontend/junior/javascript-fundamentals/components/js-basics.tsx
+++ b/src/app/frontend/junior/javascript-fundamentals/components/js-basics.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Callout, CodeBlock, Header, SectionCard, Text } from '@/components';
+
+export function JsBasics() {
+  return (
+    <SectionCard title='JavaScript Overview'>
+      <div className='space-y-6'>
+        <div>
+          <Header>What is JavaScript?</Header>
+          <Text>
+            JavaScript (JS) runs in the browser and lets you add interactivity to
+            web pages. Modern JS can also run on servers with Node.js.
+          </Text>
+          <Callout>
+            Use JS to respond to user actions, update the page without reload and
+            handle data in the browser.
+          </Callout>
+        </div>
+
+        {(() => {
+          const basicCode = `// Print a message
+console.log('Hello world');`;
+
+          return (
+            <CodeBlock
+              code={basicCode}
+              comment='Small example'
+              language='javascript'
+              showLineNumbers={true}
+            />
+          );
+        })()}
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/app/frontend/junior/javascript-fundamentals/components/variables-and-data-types.tsx
+++ b/src/app/frontend/junior/javascript-fundamentals/components/variables-and-data-types.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import dedent from 'dedent';
+import { Callout, CodeBlock, CodeSpan, Header, SectionCard, Subheader, Text } from '@/components';
+
+export function VariablesAndDataTypes() {
+  return (
+    <SectionCard title='Variables & Data Types'>
+      <div className='space-y-6'>
+        <div>
+          <Header>Declaring Variables</Header>
+          <Text>
+            Use <CodeSpan>let</CodeSpan> for changeable values and <CodeSpan>const</CodeSpan> for values that should not be reassigned. <CodeSpan>var</CodeSpan> is old and rarely needed.
+          </Text>
+        </div>
+
+        <div>
+          <Subheader>Common Data Types</Subheader>
+          <ul className='list-inside list-disc space-y-2 text-gray-50'>
+            <li>Number</li>
+            <li>String</li>
+            <li>Boolean</li>
+            <li>Object</li>
+            <li>Array</li>
+            <li>undefined / null</li>
+          </ul>
+        </div>
+
+        {(() => {
+          const code = dedent`let count = 1;
+const name = 'Sam';
+const active = true;
+const user = { id: 1, name: 'Sam' };
+const items = [1, 2, 3];`;
+          return (
+            <CodeBlock
+              code={code}
+              comment='Variables in action'
+              language='javascript'
+              showLineNumbers={true}
+            />
+          );
+        })()}
+
+        <Callout>
+          <strong>Senior note:</strong> <CodeSpan>const</CodeSpan> only prevents reassignment. The object it holds can still change.
+        </Callout>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/app/frontend/junior/javascript-fundamentals/javascript-fundamentals.tsx
+++ b/src/app/frontend/junior/javascript-fundamentals/javascript-fundamentals.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { PageHeader, TableOfContents } from '@/components';
+import {
+  JsBasics,
+  VariablesAndDataTypes,
+  FunctionsAndScope,
+  ArraysAndObjects,
+  DomManipulation,
+  AsyncJavaScript,
+} from './components';
+
+export default function JavaScriptFundamentals() {
+  return (
+    <div className='min-h-screen text-white'>
+      <PageHeader
+        description='Variables, functions, DOM basics, async code'
+        title='JavaScript Fundamentals'
+        topicHome='/frontend/junior'
+      />
+
+      {/* Spacer to account for fixed header */}
+      <div className='h-[140px]' />
+
+      <TableOfContents />
+
+      <div className='mx-auto max-w-4xl px-6 py-8'>
+        <div className='prose prose-invert prose-zinc max-w-none'>
+          <JsBasics />
+          <VariablesAndDataTypes />
+          <FunctionsAndScope />
+          <ArraysAndObjects />
+          <DomManipulation />
+          <AsyncJavaScript />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/frontend/junior/javascript-fundamentals/page.tsx
+++ b/src/app/frontend/junior/javascript-fundamentals/page.tsx
@@ -1,0 +1,3 @@
+import JavaScriptFundamentals from './javascript-fundamentals';
+
+export default JavaScriptFundamentals;


### PR DESCRIPTION
## Summary
- create a new `JavaScript Fundamentals` section with subtopics
- export the new page and link it from the Frontend Junior home page

## Testing
- `npm run format` *(fails: Error: canceled)*
- `npm run lint` *(fails: Error: canceled)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687905ce756483289ef1078e6eb9502c